### PR TITLE
Use asteroid>=0.5.0 instead of master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ musdb
 SoundFile
 scipy
 norbert
-git+https://github.com/asteroid-team/asteroid.git
+asteroid>=0.5.0


### PR DESCRIPTION
Just made a release with the new `XUMX` model for that. 

Release notes are [here](https://github.com/asteroid-team/asteroid/releases/tag/v0.5.0).